### PR TITLE
Redid logic for clipping, introduced regex and timestamp class, also added test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,21 @@ Get comments from youtube video that follow a specific time stamp format. Clip t
 
 ### How to use - user
 #### clip ($c)
-- format: `$c xx:xx-yy:yy`. Note that times like 1:24 should be written as 01:24
-
-#### clip and slow ($cs)
-- format: `$cs xx:xx-yy:yy aa:aa-bb:bb`
-- the time from `aa:aa-bb:bb` will be played right after the clip from `xx:xx-yy:yy` but in slow motion
+- format: `$c xx:xx-yy:yy`. Note that times like 1:24 can be written as either 01:24 or 1:24
 
 #### download ($d) - dev only command
 - format: `$d xx:xx-yy:yy`
 - downloads the timestamp/clip to /DownloadedClips
 
+#### slow ($s)
+- format: `$s xx:xx-yy:yy`. Plays the clip in slow motion
+
 #### fast forward ($f)
 - format `$f xx:xx-yy:yy`
 - plays the timestamp 50x faster than normal
+
+Certain features can be combined such as clip and slow:
+
+#### clip and slow ($cs)
+- format: `$c xx:xx-yy:yy $s aa:aa-bb:bb`
+- the time from `aa:aa-bb:bb` will be played right after the clip from `xx:xx-yy:yy` but in slow motion

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 import youtube_dl
 import datetime
+import re
+from timestamp import Timestamp
 
 CLIENT_SECRETS_FILE = os.path.dirname(
     os.path.realpath(__file__)) + "/client_secret.json"
@@ -82,80 +84,6 @@ def getComments(service, videoId):
     print("Comments found: " + str(comments) + NEW_LINE)
     return comments
 
-# Only supports comments in this format $c xx:xx-yy:yy
-def getTimestamps(comments):
-    timestamps = []
-    for comment in comments:
-        try:
-            if comment[0:2] == '$c':
-                timestamp = (comment[3:8], comment[9:14])
-                seconds = convertTimestampToSeconds(timestamp)
-                if seconds is not None:
-                    timestamps.append(seconds)
-        except:
-            pass
-
-    print("Timestamps found: " + str(timestamps) + NEW_LINE)
-    return timestamps
-
-# Only supports comments in this format $cs xx:xx-yy:yy aa:aa-bb:bb
-def getSlowMotionTimestamps(comments):
-    timestamps = []
-    for comment in comments:
-        try:
-            if comment[0:3] == '$cs':
-                timestamp = ((comment[4:9], comment[10:15]), (comment[16:21], comment[22:27]))
-                seconds = (convertTimestampToSeconds(timestamp[0]), convertTimestampToSeconds(timestamp[1]))
-                if seconds is not None and seconds[0] is not None and seconds[1] is not None:
-                    timestamps.append(seconds)
-        except:
-            pass
-
-    print("Slow motion timestamps found: " + str(timestamps) + NEW_LINE)
-    return timestamps
-
-# Only supports comments in this format $d xx:xx-yy:yy
-def getDownloadTimestamps(comments):
-    timestamps = []
-    for comment in comments:
-        try:
-            if comment[0:2] == '$d':
-                timestamp = (comment[3:8], comment[9:14])
-                seconds = convertTimestampToSeconds(timestamp)
-                if seconds is not None:
-                    timestamps.append(seconds)
-        except:
-            pass
-
-    print("Download timestamps found: " + str(timestamps) + NEW_LINE)
-    return timestamps
-
-# Only supports comments in this format $f xx:xx-yy:yy
-# f for fast forward
-def getTimeLapseTimestamps(comments):
-    timestamps = []
-
-    for comment in comments:
-        try:
-            if comment[0:2] == '$f':
-                timestamp = (comment[3:8], comment[9:14])
-                seconds = convertTimestampToSeconds(timestamp)
-                if seconds is not None:
-                    timestamps.append(seconds)
-        except:
-            pass
-
-    print("Time lapse timestamps found: " + str(timestamps) + NEW_LINE)
-    return timestamps
-
-def convertTimestampToSeconds(timestamp):
-    try:
-        startTime = int(timestamp[0][0:2])*60 + int(timestamp[0][3:5])
-        endTime = int(timestamp[1][0:2])*60 + int(timestamp[1][3:5])
-        return startTime, endTime
-    except:
-        pass
-
 def processUrlInput():
     urls = []
     while True:
@@ -207,6 +135,34 @@ def processMusicInput(clip_len):
         print(e)
         return None
 
+def getAllTimestamps(comments):
+    # Regex to get all matching comments
+    timestamps = []
+    for comment in comments:
+        regex = "\$([a-z]{1,2})\s([0-9]{1,2}):([0-9]{2})-([0-9]{1,2}):([0-9]{2})"
+        groups = re.findall(regex,comment)
+        prevTime = None
+        for group in groups:
+            currTime = Timestamp(*group)
+            if prevTime:
+                prevTime.next = currTime
+                currTime.prev = prevTime
+            prevTime = currTime
+        # We only want to append the first timestamp of a comment
+        timestamps.append(currTime.head())
+        
+    # Sort comments by chronological order of the first given timestamp in a comment
+    # We can sort faster by sorting the timestamps upon insertion but that's too much effort and we don't have that many timestamps lol
+    timestamps.sort()
+    return timestamps
+
+CLIP = "c"
+CLOSED_CAPTIONING = "cc"
+DOWNLOAD = "d"
+FAST_FORWARD = "f"
+NO_MUSIC = "nm"
+SLOW = "s"
+
 def processClips(urls, currentDirectory):
     clips = []
     for idx, url in enumerate(urls):
@@ -215,31 +171,34 @@ def processClips(urls, currentDirectory):
 
         downloadVideo(videoDirectory, videoId, url)
         comments = getComments(service, videoId)
-
-        timestamps = getTimestamps(comments)
-        for timestamp in timestamps:
-            clips.append(VideoFileClip(videoDirectory + "/" + videoId + ".mp4").subclip(timestamp[0], timestamp[1]))
-
-        slowMotionTimeStamps = getSlowMotionTimestamps(comments)
-        for timestamp in slowMotionTimeStamps:
-            clips.append(VideoFileClip(videoDirectory + "/" + videoId + ".mp4").subclip(timestamp[0][0], timestamp[0][1]))
-            clips.append(VideoFileClip(videoDirectory + "/" + videoId + ".mp4").subclip(timestamp[1][0], timestamp[1][1]).fx(vfx.speedx, 0.3))
-
-        downloadTimeStamps = getDownloadTimestamps(comments)
+        timestamps = getAllTimestamps(comments)
+        clipPath = videoDirectory + "/" + videoId + ".mp4"
         downloadsDirectory = currentDirectory + "/DownloadedClips"
-        if not os.path.exists(downloadsDirectory):
-            os.mkdir(downloadsDirectory)
-        for timestamp in downloadTimeStamps:
-            downloadClip = VideoFileClip(videoDirectory + "/" + videoId + ".mp4").subclip(timestamp[0], timestamp[1])
-            downloadClip.write_videofile(downloadsDirectory + "/" + str(timestamp[0]) + str(timestamp[1]) + ".mp4")
-            downloadClip.close()
-
-        timelapseTimeStamps = getTimeLapseTimestamps(comments)
-        for timestamp in timelapseTimeStamps:
-            new_clip = VideoFileClip(videoDirectory + "/" + videoId + ".mp4").subclip(timestamp[0], timestamp[1])
-            new_clip.audio = None
-            clips.append(new_clip.fx(vfx.speedx, 60))
-
+        
+        for timestamp in timestamps:
+            while timestamp is not None:
+                if timestamp.command == CLIP:
+                    clips.append(VideoFileClip(clipPath).subclip(timestamp.startTime, timestamp.endTime))
+                elif timestamp.command == CLOSED_CAPTIONING:
+                    # TODO
+                    pass
+                elif timestamp.command == DOWNLOAD:
+                    if not os.path.exists(downloadsDirectory):
+                        os.mkdir(downloadsDirectory)
+                    downloadClip = VideoFileClip(clipPath).subclip(timestamp.startTime, timestamp.endTime)
+                    downloadClip.write_videofile(downloadsDirectory + "/" + str(timestamp.startTime) + str(timestamp.endTime) + ".mp4")
+                    downloadClip.close()
+                elif timestamp.command == FAST_FORWARD:
+                    new_clip = VideoFileClip(clipPath).subclip(timestamp.startTime, timestamp.endTime)
+                    new_clip.audio = None
+                    clips.append(new_clip.fx(vfx.speedx, 60))
+                elif timestamp.command == NO_MUSIC:
+                    # TODO
+                    pass
+                elif timestamp.command == SLOW:
+                    clips.append(VideoFileClip(clipPath).subclip(timestamp.startTime, timestamp.endTime).fx(vfx.speedx, 0.3))
+                print(timestamp)
+                timestamp = timestamp.next
     return clips
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -24,10 +24,9 @@ class TestGetTimestampRegex(unittest.TestCase):
         output = getAllTimestamps(["$c 2:24-3:45 $s 02:25-03:40"])
         expectedTimestamp1 = Timestamp("c", "2","24","3","45")
         expectedTimestamp2 = Timestamp("s", "2","25","3","40")
-        self.assertEqual(len(output),1)
+        self.assertEqual(len(output),2)
         self.assertEqual(output[0],expectedTimestamp1)
-        self.assertEqual(output[0].next,expectedTimestamp2)
-        self.assertEqual(output[0].next.prev,expectedTimestamp1)
+        self.assertEqual(output[1],expectedTimestamp2)
         
     # Test singular timestamps in a multiple comment
     def test_single_timestamp_multiple_comments(self):
@@ -37,8 +36,6 @@ class TestGetTimestampRegex(unittest.TestCase):
         self.assertEqual(len(output),2)
         self.assertEqual(output[0],expectedTimestamp1)
         self.assertEqual(output[1],expectedTimestamp2)
-        self.assertEqual(output[0].next,None)
-        self.assertEqual(output[1].next,None)
         
     # Test timestamps are sorted
     def test_sorted_timestamp(self):
@@ -49,11 +46,11 @@ class TestGetTimestampRegex(unittest.TestCase):
         expectedTimestamp3 = Timestamp("w", "2","26","2","28")
         expectedTimestamp4 = Timestamp("f", "50", "34", "55", "24")
 
-        self.assertEqual(len(output),3)
+        self.assertEqual(len(output),4)
         self.assertEqual(output[0],expectedTimestamp1)
         self.assertEqual(output[1],expectedTimestamp2)
-        self.assertEqual(output[0].next,expectedTimestamp3)
-        self.assertEqual(output[2],expectedTimestamp4)
+        self.assertEqual(output[2],expectedTimestamp3)
+        self.assertEqual(output[3],expectedTimestamp4)
 
         
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,0 +1,60 @@
+import unittest
+from main import getAllTimestamps
+from timestamp import Timestamp
+class TestGetTimestampRegex(unittest.TestCase):
+    
+    # Test a single timestamp
+    def test_single_timestamp(self):
+        output = getAllTimestamps(["$c 02:24-03:45"])
+        expectedTimestamp = Timestamp("c", "02","24","03","45")
+        
+        self.assertEqual(len(output),1)
+        self.assertEqual(output[0],expectedTimestamp)
+        
+    # Test timestamps without leading 0
+    def test_timestamp_without_0(self):
+        output = getAllTimestamps(["$c 2:24-3:45"])
+        expectedTimestamp = Timestamp("c", "2","24","3","45")
+        
+        self.assertEqual(len(output),1)
+        self.assertEqual(output[0],expectedTimestamp)
+
+    # Test multiple timestamps in a singular comment
+    def test_multiple_timestamps_single_comment(self):
+        output = getAllTimestamps(["$c 2:24-3:45 $s 02:25-03:40"])
+        expectedTimestamp1 = Timestamp("c", "2","24","3","45")
+        expectedTimestamp2 = Timestamp("s", "2","25","3","40")
+        self.assertEqual(len(output),1)
+        self.assertEqual(output[0],expectedTimestamp1)
+        self.assertEqual(output[0].next,expectedTimestamp2)
+        self.assertEqual(output[0].next.prev,expectedTimestamp1)
+        
+    # Test singular timestamps in a multiple comment
+    def test_single_timestamp_multiple_comments(self):
+        output = getAllTimestamps(["$c 2:24-3:45", "$s 02:25-03:40"])
+        expectedTimestamp1 = Timestamp("c", "2","24","3","45")
+        expectedTimestamp2 = Timestamp("s", "2","25","3","40")
+        self.assertEqual(len(output),2)
+        self.assertEqual(output[0],expectedTimestamp1)
+        self.assertEqual(output[1],expectedTimestamp2)
+        self.assertEqual(output[0].next,None)
+        self.assertEqual(output[1].next,None)
+        
+    # Test timestamps are sorted
+    def test_sorted_timestamp(self):
+        output = getAllTimestamps(["$f 50:34-55:24", "$c 2:24-3:45 $w 2:26-2:28", "$s 02:25-03:40"])
+        
+        expectedTimestamp1 = Timestamp("c", "2","24","3","45")
+        expectedTimestamp2 = Timestamp("s", "2","25","3","40")
+        expectedTimestamp3 = Timestamp("w", "2","26","2","28")
+        expectedTimestamp4 = Timestamp("f", "50", "34", "55", "24")
+
+        self.assertEqual(len(output),3)
+        self.assertEqual(output[0],expectedTimestamp1)
+        self.assertEqual(output[1],expectedTimestamp2)
+        self.assertEqual(output[0].next,expectedTimestamp3)
+        self.assertEqual(output[2],expectedTimestamp4)
+
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/timestamp.py
+++ b/timestamp.py
@@ -6,21 +6,7 @@ class Timestamp:
         self.endMin = endMin
         self.endSec = endSec
         self.startTime, self.endTime = self.convertTimestampToSeconds()
-        
-        # These are to associate linking timestamps within the same comment
-        self.next = None
-        self.prev = None
-    
-    def head(self):
-        if self.prev:
-            return self.prev.head()
-        return self
-    
-    def tail(self):
-        if self.tail:
-            return self.next.tail()
-        return self
-    
+
     # Custom comparator when comparing timestamps
     def __lt__(self,other):
         return self.startTime < other.startTime

--- a/timestamp.py
+++ b/timestamp.py
@@ -1,0 +1,44 @@
+class Timestamp:
+    def __init__(self,command,startMin,startSec,endMin,endSec):
+        self.command = command
+        self.startMin = startMin
+        self.startSec = startSec
+        self.endMin = endMin
+        self.endSec = endSec
+        self.startTime, self.endTime = self.convertTimestampToSeconds()
+        
+        # These are to associate linking timestamps within the same comment
+        self.next = None
+        self.prev = None
+    
+    def head(self):
+        if self.prev:
+            return self.prev.head()
+        return self
+    
+    def tail(self):
+        if self.tail:
+            return self.next.tail()
+        return self
+    
+    # Custom comparator when comparing timestamps
+    def __lt__(self,other):
+        return self.startTime < other.startTime
+    
+    # Custom comparator to define equality of timestamps
+    def __eq__(self,other):
+        return self.command == other.command and self.startTime == other.startTime and self.endTime == other.endTime
+    
+    # Command that gets outputted when print() or str() is called
+    def __str__(self):
+        return "Command is " + self.command + " from " + str(self.startTime) + " to " + str(self.endTime)
+    
+    # Time is given in a:b to c:d
+    def convertTimestampToSeconds(self):
+        SECONDS_IN_MINUTES = 60
+        try:
+            startTime = int(self.startMin)*SECONDS_IN_MINUTES+int(self.startSec)
+            endTime = int(self.endMin)*SECONDS_IN_MINUTES+int(self.endSec)
+            return startTime, endTime
+        except:
+            pass


### PR DESCRIPTION
Redid logic for clipping, every comment must now match the form :\$([a-z]{1,2})\s([0-9]{1,2}):([0-9]{2})-([0-9]{1,2}):([0-9]{2}), which means `$cs xx:xx-yy:yy aa:aa-bb:bb` has to now be `$c xx:xx-yy:yy $s aa:aa-bb:bb`. This change will allow us to easily add stack new features in the future. Regex also allows us to be less strict on the timestamp input so we now accept both 01:24 and 1:24. Closes #9. This restructuring also allows us to begin on #6 and #7 

Created a timestamp class to deal with processing timestamps easily. Also sorted timestamps in chronological order before processing. Closes #10. 

Test cases were added to test regex for timestamps.