### PR TITLE
remove the need to change file names to avoid downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Get comments from youtube video that follow a specific time stamp format. Clip t
 
 ### How to use - dev
 1. enter links, press enter after each link
-2. press f to start generating highlights
-3. after the highlight video has been processed, the program will ask if you would like to add music to the video. Enter an arbitrary number of youtube links if you want to include the audio or enter f to skip
+2. press f to proceed
+3. indicate y/n if the video URLs need to be downloaded from Youtube. In the case that you already have the videos on your local computer, ensure that they are in `/Videos` and that the name of the file is the exact same as the title of the video on Youtube. (e.g. Youtube Video Title == GX013489 == Video Name File == GX013489.mp4)
+4. after the highlight video has been processed, the program will ask if you would like to add music to the video. Enter an arbitrary number of youtube links if you want to include the audio or enter f to skip
 
 ### How to use - user
 #### captions ($cc)
@@ -28,7 +29,7 @@ Get comments from youtube video that follow a specific time stamp format. Clip t
 - format: `$c xx:xx-yy:yy`. Note that times like 1:24 can be written as either 01:24 or 1:24
 
 #### clip and no music($cnm)
-- format: `$cnm xx:xx-yy:yy`. Play a clip without music 
+- format: `$cnm xx:xx-yy:yy`. Play a clip without music
 
 #### download ($d) - dev only command
 - format: `$d xx:xx-yy:yy`

--- a/main.py
+++ b/main.py
@@ -61,7 +61,6 @@ def downloadVideo(directory, filename, url):
             filename = info_dict.get('title', None)
 
     if not os.path.exists(directory + "/" + filename + ".mp4"):
-        # 137 is 1920x1080 don't ask me how it just is
         ydl_opts = {'format_sort': ['res:1080', 'ext:mp4:m4a'],
                     'outtmpl': directory + "/" + filename}
         with YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
Previously, in order to avoid downloading youtube videos, files would be placed in `/Videos` and their file name would have to match their Youtube ID. In other words, if the youtube id (in the URL) matches the name of the file in `/Videos`, then we interpret as the local video and youtube video being the same video. This produces manual work in renaming the mp4 files from whatever their original name was to whatever their Youtube ID is one by one.

This PR allows the user to indicate if they already have the files in their `/Videos`. If they do, these file names must match the name that is on the Youtube video. e.g. 

![image](https://user-images.githubusercontent.com/45786074/210779715-db599854-48dd-4905-9bd3-5203f857097f.png)
![image](https://user-images.githubusercontent.com/45786074/210779787-396b5d90-7023-4fa5-8822-f37677015866.png)

This removes the need to change the file names. Also, the new `yt-dlp` api is much faster at downloading so downloading isn't so bad either. 
