### PR TITLE
implement script that formats gopro files for easier youtube upload

### DIFF
--- a/format_gopro_files.py
+++ b/format_gopro_files.py
@@ -1,0 +1,51 @@
+import os
+
+PATH = './Videos'
+
+def getListOfFiles():
+    videoDir = os.scandir(PATH)
+    files = []
+    for file in videoDir:
+        if file.is_file():
+            files.append({
+                'fileObj': file,
+                'name': file.name
+            })
+
+    videoDir.close()
+
+    return files
+
+# assuming that files are always formatted like "GX<YY><XXXX>"
+# create an object where all the keys are <XXXX>
+# e.g. {
+#   "3656": [
+#       "GX013565",
+#       "GX023565"
+#   ]
+# }
+def getGroupedRecordings(files):
+    res = {}
+    for file in files:
+        recordingID = int(file["name"][4:8])
+        if recordingID in res.keys():
+            res[recordingID].append(file["name"])
+        else:
+            res[recordingID] = [file["name"]]
+    return res
+
+
+
+if __name__ == "__main__":
+    files = getListOfFiles()
+    # testFile = files[-1]
+    # print(testFile)
+    # os.rename("{}/gottem.txt".format(PATH), "{}/testing.txt".format(PATH))
+
+    groupedRecordings = getGroupedRecordings(files)
+    fileCounter = 0
+    # the keys should be in sorted order (windows default)
+    for key in groupedRecordings.keys():
+        for subrecordingID in groupedRecordings[key]:
+            os.rename("{}/{}".format(PATH, subrecordingID), "{}/{}".format(PATH, str(fileCounter) + subrecordingID))
+            fileCounter += 1

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ EMPTY_DELETE_MESSAGE = "Nothing to delete." + NEW_LINE
 SLOW_MO_RATE = 0.3
 FADEWAY_TIME = 3
 FAST_FORWARD_RATE = 60
-MUSIC_LOUDNESS_FACTOR = 0.4
+MUSIC_LOUDNESS_FACTOR = 0.5
 
 CLIP = "c"
 CLIP_NO_MUSIC = "cnm"
@@ -76,6 +76,7 @@ def downloadMusic(directory, filename, url):
             'preferredcodec': 'mp3',
             'preferredquality': '192',
         }],
+        'keepvideo': True,
         'outtmpl': directory + "/" + filename + ".mp3"
         }
     with YoutubeDL(ydl_opts) as ydl:
@@ -90,7 +91,7 @@ def getComments(service, videoId):
     response = service.commentThreads().list(
         part="snippet",
         maxResults=100,
-        videoId=videoId
+        videoId=videoId,
     ).execute()
 
     numComments = response['pageInfo']['totalResults']


### PR DESCRIPTION
Closes #16 

new behavior:
run `python format_gopro_files.py` with the raw footage in the ./Videos directory. The correct ordering of the raw footage will be appended onto the name (e.g. 0<file name>, 1<file name>, 2<file name>). Now, all the videos can be selected and uploaded at once on Youtube while maintaining the chronological order that they were recorded in. (shown below)

![image](https://github.com/Resocram/youtube_highlights/assets/45786074/26adabaf-4309-4eaa-8b8d-8af566681dee)
![image](https://github.com/Resocram/youtube_highlights/assets/45786074/9415c6f7-dbd1-48de-b288-a2647931adf0)

